### PR TITLE
認証番号確認view/class名修正

### DIFF
--- a/app/assets/stylesheets/users/_authentication.scss
+++ b/app/assets/stylesheets/users/_authentication.scss
@@ -1,14 +1,11 @@
 .authentication-contents {
-  width: 100vw;
-
-  .main-items {
+  .authentication-mainitems{
     width: 700px;
     height: 986px;
-    background-color: colors(white);
     text-align: center;
     margin: 0 auto;
 
-    .title {
+    &__title {
       text-align: center;
       background-color: colors(white);
       width: 700px;
@@ -18,45 +15,49 @@
       font-weight: 550;
       margin-bottom: 2px;
     }
-    .input-screen {
-      background-color: colors(white);
-      width: 700px;
-      height: 350px;
-      margin-bottom: 2px;
+  }
 
-      .content {
-        padding-top: 40px;
-        margin: 0px 145px;
-        padding: 45px;
-        text-align: left;
+  .authentication-input-screen{
+    background-color: colors(white);
+    width: 700px;
+    height: 350px;
+    margin-bottom: 2px;
 
+    &__maincontent {
+      padding-top: 40px;
+      margin: 0px 145px;
+      padding: 45px;
+      text-align: left;
+
+      &__text {
+        font-size: 13px;
+      }
+      &__authentication {
+        margin: 40px 0px;
         &__text {
-          font-size: 13px;
+          padding-bottom: 10px;
+          font-size: 14px;
+          font-weight: 600;
         }
-        &__authentication {
-          margin: 40px 0px;
-          &__text {
-            padding-bottom: 10px;
-            font-size: 14px;
-            font-weight: 600;
-          }
-          &__input {
-            height: 40px;
-            width: 320px;
-            border-radius: 5px;
-            border: solid 1px #80808073;
-          }
+        
+        &__input {
+          height: 40px;
+          width: 320px;
+          border-radius: 5px;
+          border: solid 1px #80808073;
         }
         &__submit-btn {
           @include btn;
           margin-top: 40px;
           background-color: colors(btn-red);
-        }
+        
       }
     }
   }
+}
+}
 
-  .no-reach {
+  .no-reachnumber {
     background-color: colors(white);
     height: 545px;
     width: 700px;
@@ -98,5 +99,5 @@
         }
       }
     }
-  }
+  
 }

--- a/app/views/users/authentication.html.haml
+++ b/app/views/users/authentication.html.haml
@@ -1,21 +1,21 @@
 = render 'shared/logo-onlyheader'
 .authentication-contents
-  .main-items
-    .title
+  .authentication-mainitems
+    .authentication-mainitems__title
       認証番号の確認
-    .input-screen
-      .content
-        .content__text
+    .authentication-input-screen
+      .authentication-input-screen__maincontent
+        .authentication-input-screen__maincontent__text
           ***-****-1234にSMSでお送りした6桁の認証番号を入力してください。
-        .content__authentication
-          .content__authentication__text
+        .authentication-input-screen__maincontent__authentication
+          .authentication-input-screen__maincontent__authentication__text
             認証番号
-          .content__authentication__inputs
-            %input{type: "text", placeholder:"6桁の暗証番号を入力", class: "content__authentication__input"}
+            
+          %input{type: "text", placeholder:"6桁の暗証番号を入力", class: "authentication-input-screen__maincontent__authentication__input"}
 
-            %button{type: "submit", class: "content__submit-btn"}
-              認証して完了
-    .no-reach
+          %button{type: "submit", class: "authentication-input-screen__maincontent__authentication__submit-btn"}
+            認証して完了
+    .no-reachnumber
       .no-reach-content
         .no-reach-content__guide
           60秒たっても認証番号が届かない方へ

--- a/app/views/users/registrationNewmenbar.html.haml
+++ b/app/views/users/registrationNewmenbar.html.haml
@@ -1,5 +1,5 @@
 .registrationNewmenbar-body  
-  = render 'users/userResist-logo-gray'
+  = render 'shared/logo-onlyheader'
   .registrationNewmenbar-maincontent
     .registrationNewmenbar-maincontent__contents
       .registrationNewmenbar-maincontent__contents__header


### PR DESCRIPTION

# What
認証番号確認ページのviewのクラス名を修正しました。

# Why
クラス名が単純だったため。
アンバサンドを使用していなかったため。

![screencapture-localhost-3000-users-authentication-2019-10-10-16_58_25](https://user-images.githubusercontent.com/54015798/66549892-44411280-eb7f-11e9-8f89-7f0c63df0fcd.png)
